### PR TITLE
Improve first-run onboarding for content monitoring positioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env when using docker compose locally.
+# This file mainly controls local container naming / UID mapping.
+
+# Host user mapping for the dev container defined in docker-compose.yml
+BUILDUID=1000
+USER=app
+
+# Optional: override service ports if the defaults conflict locally.
+MONGO_PORT=27017
+RABBITMQ_PORT=5672
+RABBITMQ_MANAGEMENT_PORT=15672
+MEMCACHED_PORT=11211
+WEB_PORT=5000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libxml2-dev libxslt1-dev zlib1g-dev
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r requirements_dev.txt
+      - name: Build locked test environment
+        run: make venv PYTHON=python
       - name: Run unit tests
-        run: python -m unittest discover -s utests -v
+        run: make test PYTHON=python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev libxslt1-dev zlib1g-dev
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements_dev.txt
+      - name: Run unit tests
+        run: python -m unittest discover -s utests -v

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: services-up services-down dev test lint
+PYTHON ?= python3.9
+VENV ?= .venv
+PYTHON_BIN := $(VENV)/bin/python
+PIP_BIN := $(VENV)/bin/pip
+CONSTRAINTS ?= constraints/py39.txt
+
+.PHONY: services-up services-down venv dev test lint
 
 services-up:
 	docker compose -f docker-compose.services.yml up -d
@@ -6,11 +12,18 @@ services-up:
 services-down:
 	docker compose -f docker-compose.services.yml down
 
+$(PYTHON_BIN):
+	$(PYTHON) -m venv $(VENV)
+
+venv: $(PYTHON_BIN)
+	$(PIP_BIN) install --upgrade pip setuptools wheel
+	$(PIP_BIN) install -r requirements_dev.txt -c $(CONSTRAINTS)
+
 dev:
 	./scripts/dev-start.sh
 
-test:
-	./.venv/bin/python -m unittest discover -s utests -v
+test: venv
+	$(PYTHON_BIN) -m unittest discover -s utests -v
 
-lint:
-	./.venv/bin/python -m compileall zspider utests
+lint: venv
+	$(PYTHON_BIN) -m compileall zspider utests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: services-up services-down dev test lint
+
+services-up:
+	docker compose -f docker-compose.services.yml up -d
+
+services-down:
+	docker compose -f docker-compose.services.yml down
+
+dev:
+	./scripts/dev-start.sh
+
+test:
+	./.venv/bin/python -m unittest discover -s utests -v
+
+lint:
+	./.venv/bin/python -m compileall zspider utests

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd zspider
 cp .env.example .env
 python3.9 -m venv .venv
 ./.venv/bin/pip install -U pip setuptools wheel
-./.venv/bin/pip install -r requirements_dev.txt
+./.venv/bin/pip install -r requirements_dev.txt -c constraints/py39.txt
 ```
 
 ### 2）一键启动依赖服务

--- a/README.md
+++ b/README.md
@@ -1,140 +1,184 @@
-# ZSPIDER
+# ZSpider
 
+[![CI](https://github.com/Zephor5/zspider/actions/workflows/ci.yml/badge.svg)](https://github.com/Zephor5/zspider/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/zspider/badge/?version=latest)](http://zspider.readthedocs.org/en/latest/?badge=latest)
 
-面向**内容监控 / 资讯聚合**场景的自托管抓取平台。
+面向 **内容监控 / 资讯聚合** 场景的自托管抓取平台。
 
-ZSpider 适合用于持续采集新闻、公告、公众号、资讯站点等公开网页内容：你可以通过 Web 后台管理任务、配置解析规则、定时抓取并统一查看结果。
+ZSpider 不是“写几个爬虫脚本然后自己拼调度”的工具，而是一套带 **Web 后台、定时调度、配置化解析、结果查看** 的平台化抓取系统，适合持续监控新闻、公告、公众号和各类公开网页内容。
 
 [English README](README_EN.md)
 
 ---
 
-## ZSpider 是什么
+## 它适合什么场景
 
-ZSpider 不是一个只负责“写爬虫代码”的脚手架，而是一套更偏平台化的抓取系统：
+ZSpider 更适合“持续运行的内容采集任务”，而不是一次性脚本：
 
-- 用 **Web 后台** 管理抓取任务，而不是散落在各处的脚本
-- 用 **Cron 调度** 持续监控内容更新，而不是手工触发
-- 用 **配置化解析** 提取结构化字段，而不是每次都重写逻辑
-- 用 **统一存储与查看** 管理抓取结果，而不是临时输出到日志
+- **新闻 / 资讯聚合**：监控多个媒体站点，统一采集标题、正文、时间、来源
+- **公告监控**：追踪政府、学校、企业官网的公告更新
+- **公众号采集**：抓取公众号文章列表和正文，做归档或二次分析
+- **行业情报收集**：持续拉取公开网页内容，用于研究、投研、舆情或专题跟踪
+- **自建抓取后台**：把任务、字段、结果、日志放在同一套后台中集中管理
 
-如果你的目标是做：
-- 新闻 / 资讯聚合
-- 政务公告 / 招标公告监控
-- 企业官网动态跟踪
-- 微信公众号内容采集
-- 研究资料与公开信息持续收集
-
-那么 ZSpider 会比“单个爬虫脚本”更像一个可持续运转的工具。
+如果你的目标是“长期稳定地监控内容变化”，ZSpider 会比零散脚本更省心。
 
 ---
 
-## 特性
+## 核心能力
 
-- 🕷️ **平台化抓取** - 面向内容监控与资讯聚合的任务管理平台
-- ⏰ **定时调度** - 基于 APScheduler 的 Cron 定时任务
-- 🌐 **Web 管理** - Flask 后台可视化管理任务、字段与结果
-- 📦 **可配置解析** - XPath + 正则表达式配置化提取
-- 🔐 **登录支持** - 自动处理需要登录的网站
-- 🔄 **去重机制** - 基于 Memcached 的分布式 URL 去重
-- 🚚 **可扩展架构** - Dispatcher / Crawler 解耦，支持横向扩展
-
----
-
-## 适用场景
-
-| 场景 | 说明 |
-|------|------|
-| 新闻监控 | 定时抓取新闻站点，做资讯聚合或专题追踪 |
-| 公告追踪 | 监控政府、学校、企业官网公告更新 |
-| 微信内容采集 | 抓取公众号文章列表与正文，用于归档或分析 |
-| 行业情报收集 | 面向研究、投研、舆情、情报等公开信息收集 |
-| 自建内容后台 | 将抓取任务、解析规则、结果查看集中到一套后台中 |
+- 🕷️ **平台化任务管理**：通过 Web 后台集中管理抓取任务和字段配置
+- ⏰ **定时调度**：基于 APScheduler 的 Cron 任务调度
+- 🌐 **可视化后台**：查看任务状态、抓取结果、运行日志
+- 📦 **配置化解析**：支持 XPath + 正则提取，不必每次都重写代码
+- 🔐 **登录站点支持**：支持需要登录态的网站抓取
+- 🔄 **去重机制**：基于 Memcached 的 URL 去重和心跳机制
+- 🚚 **可扩展架构**：Dispatcher / Crawler 解耦，可横向扩展 Worker
 
 ---
 
 ## 为什么不是普通爬虫脚本
 
-当抓取需求从“一次性脚本”变成“持续运营的内容采集任务”时，团队通常会遇到这些问题：
+当需求从“一次抓完”变成“持续监控”后，团队通常会开始遇到这些问题：
 
 - 任务分散在多个脚本里，不好管理
-- 定时执行依赖 crontab / supervisor，维护成本高
-- 解析规则改动后，缺少统一的任务入口和结果查看方式
-- 多个站点并行抓取时，状态、日志、结果难以集中管理
+- 调度依赖 crontab / supervisor，链路分散
+- 解析规则改完后，没有统一入口重新验证
+- 多站点并发后，日志、状态、结果难以集中查看
 
-ZSpider 的目标不是替代所有爬虫开发方式，而是把这类**持续抓取 + 定时调度 + 结果管理**的工作，沉淀成一套更容易运转的平台。
+ZSpider 的目标就是把这类 **持续抓取 + 定时调度 + 结果管理** 的工作沉淀成一套更容易跑起来、也更容易交接的平台。
 
 ---
 
-## 快速开始
+## 5 分钟快速体验
 
-### 1. 克隆项目
+### 1）准备环境
+
+推荐使用 Python 3.9：
 
 ```bash
 git clone https://github.com/Zephor5/zspider.git
 cd zspider
+cp .env.example .env
+python3.9 -m venv .venv
+./.venv/bin/pip install -U pip setuptools wheel
+./.venv/bin/pip install -r requirements_dev.txt
 ```
 
-### 2. 安装依赖
+### 2）一键启动依赖服务
 
 ```bash
-pip install -r requirements.txt
+make services-up
 ```
 
-### 3. 启动外部服务
+会启动：
+
+- MongoDB
+- RabbitMQ
+- Memcached
+
+### 3）启动 ZSpider 本地开发栈
 
 ```bash
-docker compose -f docker-compose.services.yml up -d
+make dev
 ```
 
-### 4. 启动 ZSpider 组件
+这个命令会统一启动：
+
+- `zspider.dispatcher`
+- `zspider.crawler`
+- `zspider.web`
+
+默认访问地址：
+
+```text
+http://127.0.0.1:5000
+```
+
+### 4）初始化管理员账号
+
+第一次访问 `/login` 时：
+
+- **输入任意账号和密码**
+- 如果当前用户表为空，这组凭据会被写入并成为 **首个管理员账号**
+
+也就是说，项目当前没有预置默认管理员账号，**首次登录输入的账号 / 密码就是初始化管理员账号**。
+
+### 5）验证是否跑通
+
+- 打开后台首页，确认能访问 Dashboard
+- 登录后新建任务 / 查看任务页是否正常打开
+- 查看 `logs/web.log`、`logs/dispatcher.log`、`logs/crawler.log` 是否有异常
+
+停止服务：
 
 ```bash
-python -m zspider.dispatcher
-python -m zspider.crawler
-python -m zspider.web
+# Ctrl + C 停止 make dev 启动的本地进程
+make services-down
 ```
 
-> 详细环境要求、配置文件说明、组件介绍、Parser / Pipeline / 项目结构等专业开发文档，请查看 `docs/` 或 Read the Docs。
+---
+
+## 本地开发的统一入口
+
+为了减少“到底先起哪个组件”的理解成本，仓库现在提供了统一入口：
+
+```bash
+make dev
+```
+
+它会：
+
+1. 自动拉起 `docker-compose.services.yml` 里的依赖
+2. 用当前仓库 `.venv` 启动 dispatcher / crawler / web
+3. 将日志写入 `logs/dispatcher.log`、`logs/crawler.log`、`logs/web.log`
+
+如果你只想启动外部依赖：
+
+```bash
+make services-up
+```
+
+如果你只想运行测试：
+
+```bash
+make test
+```
+
+---
+
+## 当前基础信任信号
+
+第一阶段先补最基础、最直接影响首次判断的信号：
+
+- 已补 **GitHub Actions CI**：默认执行单元测试
+- 仓库现有 **27 个单元测试**，可通过 `make test` 运行
+- 已保留并补充 `docs/` 开发文档入口
+- README 已补充：定位、场景、快速体验、初始化说明、统一启动方式
+
+当前仍未完成但后续值得继续补的部分：
+
+- 后台截图 / GIF
+- 更贴近真实业务的任务模板示例
+- 更明确的生产部署文档
+- 更细的健康检查 / 观测说明
 
 ---
 
 ## 系统架构
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
-│                        ZSpider 系统                          │
+│                        ZSpider 系统                         │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
-│   ┌──────────────┐      ┌──────────────┐                    │
-│   │  Dispatcher  │◄────►│  Dispatcher  │  (主备热切换）       │
-│   │   (主节点)    │      │   (备节点)    │                    │
-│   └──────┬───────┘      └──────────────┘                    │
-│          │                                                  │
-│          ▼                                                  │
-│   ┌──────────────┐                                          │
-│   │   RabbitMQ   │  任务队列                                  │
-│   └──────┬───────┘                                          │
-│          │                                                  │
-│          ▼                                                  │
-│   ┌──────────────┐   ┌──────────────┐   ┌──────────────┐    │
-│   │   Crawler    │   │   Crawler    │   │   Crawler    │    │
-│   │   (Worker)   │   │   (Worker)   │   │   (Worker)   │    │
-│   └──────┬───────┘   └──────────────┘   └──────────────┘    │
-│          │                                                  │
-│          ▼                                                  │
-│   ┌──────────────┐                                          │
-│   │   MongoDB    │  数据存储                                  │
-│   └──────────────┘                                          │
+│   Dispatcher  →  RabbitMQ  →  Crawler Workers              │
+│        │                               │                    │
+│        └──────── 状态 / 管理 ──────────┘                    │
 │                                                             │
-│   ┌──────────────┐                                          │
-│   │  Memcached   │  心跳 + 去重                               │
-│   └──────────────┘                                          │
-│                                                             │
-│   ┌──────────────┐                                          │
-│   │  Web Admin   │  管理后台                                  │
-│   └──────────────┘                                          │
+│   MongoDB   存储任务与抓取结果                              │
+│   Memcached 心跳与去重                                      │
+│   Web Admin 后台管理与查看                                  │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -143,19 +187,19 @@ python -m zspider.web
 
 ## 面向开发者的进一步阅读
 
-- [开发指南](docs/developer_guide.rst)：环境要求、配置文件、核心组件、Parser / Pipeline、项目结构
-- [架构设计](docs/desgin.rst)：架构设计说明
+- [开发指南](docs/developer_guide.rst)
+- [架构设计](docs/desgin.rst)
 - [内部消息设计](docs/internal_message.rst)
-- [数据模型](docs/item_info.rst)：数据模型与字段说明
+- [数据模型](docs/item_info.rst)
 
-完整文档可通过 Sphinx 构建：
+构建文档：
 
 ```bash
 cd docs
 make html
 ```
 
-或访问 [ReadTheDocs](http://zspider.readthedocs.org/)
+或访问 [Read the Docs](http://zspider.readthedocs.org/)。
 
 ---
 
@@ -163,8 +207,6 @@ make html
 
 MIT License
 
----
+## Contributing
 
-## 贡献
-
-欢迎提交 Issue 和 Pull Request！
+欢迎提交 Issue 和 Pull Request。

--- a/README_EN.md
+++ b/README_EN.md
@@ -62,7 +62,7 @@ cd zspider
 cp .env.example .env
 python3.9 -m venv .venv
 ./.venv/bin/pip install -U pip setuptools wheel
-./.venv/bin/pip install -r requirements_dev.txt
+./.venv/bin/pip install -r requirements_dev.txt -c constraints/py39.txt
 ```
 
 ### 2) Start dependency services

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,159 +1,205 @@
-# ZSPIDER
+# ZSpider
 
+[![CI](https://github.com/Zephor5/zspider/actions/workflows/ci.yml/badge.svg)](https://github.com/Zephor5/zspider/actions/workflows/ci.yml)
 [![Documentation Status](https://readthedocs.org/projects/zspider/badge/?version=latest)](http://zspider.readthedocs.org/en/latest/?badge=latest)
 
 A self-hosted crawling platform for **content monitoring and news aggregation**.
 
-ZSpider is built for continuously collecting public web content such as news sites, announcements, WeChat articles, and other information sources. You manage jobs in a web dashboard, configure extraction rules, schedule crawls, and review results in one place.
+ZSpider is not just a place to dump crawler scripts. It is a platform-oriented system with a **web admin, scheduling, configurable parsing, and result review**, built for recurring collection workflows such as monitoring news sites, announcements, WeChat articles, and other public web content.
 
 [中文说明](README.md)
 
 ---
 
-## What ZSpider is
+## What it is good for
 
-ZSpider is not just a crawler code scaffold. It is a more platform-oriented system for operating recurring collection workflows:
+ZSpider fits ongoing collection workflows better than one-off scripts:
 
-- manage crawl jobs from a **web dashboard** instead of scattered scripts
-- run **scheduled monitoring** with Cron rather than manual execution
-- extract structured data through **configurable parsers**
-- review and manage results through a **centralized backend**
+- **News / content aggregation** across multiple sites
+- **Announcement monitoring** for government, school, or company websites
+- **WeChat article collection** for archiving or downstream analysis
+- **Research / intelligence gathering** from public information sources
+- **Self-hosted content operations** with jobs, fields, logs, and results in one backend
 
-Typical use cases include:
-- news and article aggregation
-- public announcement monitoring
-- company website update tracking
-- WeChat content collection
-- continuous gathering of public information for research and intelligence work
+If your goal is long-running monitoring rather than a one-time scrape, ZSpider is the better fit.
 
 ---
 
-## Features
+## Core capabilities
 
-- 🕷️ **Platform-oriented crawling** - built for content monitoring and information aggregation
-- ⏰ **Cron Scheduling** - APScheduler-based timed tasks
-- 🌐 **Web Management** - Flask admin dashboard for managing jobs, fields, and results
-- 📦 **Configurable Parsing** - XPath + Regex extraction without coding
-- 🔐 **Login Support** - Automatic handling of login-required websites
-- 🔄 **Deduplication** - Memcached-based distributed URL deduplication
-- 🚚 **Scalable Architecture** - decoupled Dispatcher / Crawler design with horizontal scaling
-
----
-
-## Use Cases
-
-| Use Case | Description |
-|----------|-------------|
-| News Monitoring | Periodically crawl media sites for aggregation and topic tracking |
-| Announcement Tracking | Monitor government, school, or company websites for updates |
-| WeChat Collection | Collect article indexes and detail pages from public accounts |
-| Research / Intel Gathering | Continuously gather public information for analysis workflows |
-| Self-hosted Content Ops | Centralize crawl jobs, parser rules, and result review in one system |
+- 🕷️ **Platform-style job management** through a web admin
+- ⏰ **Scheduled crawling** powered by APScheduler Cron jobs
+- 🌐 **Visual backend** for task status, logs, and results
+- 📦 **Configurable parsing** with XPath + regex extraction
+- 🔐 **Login-aware crawling** for authenticated sites
+- 🔄 **Deduplication** backed by Memcached
+- 🚚 **Scalable architecture** with decoupled Dispatcher / Crawler components
 
 ---
 
 ## Why not plain crawler scripts
 
-When a crawler evolves from a one-off script into an ongoing collection workflow, teams usually run into the same problems:
+Once a scraper turns into an always-on monitoring workflow, teams usually hit the same problems:
 
-- jobs are scattered across scripts and hard to manage
+- jobs are scattered across many scripts
 - scheduling depends on ad-hoc crontab or supervisor setups
-- parser changes lack a unified execution and review flow
-- logs, status, and results become messy when multiple sites run in parallel
+- parser changes have no single execution path to verify them
+- logs, status, and results become fragmented across many places
 
-ZSpider is not trying to replace every crawler development style. Its goal is to make **recurring crawling + scheduled monitoring + result management** easier to operate as a platform.
+ZSpider exists to make **recurring crawling + scheduling + result management** easier to operate as a real platform.
 
 ---
 
-## Quick Start
+## 5-minute quick start
 
-### 1. Clone the project
+### 1) Prepare the environment
+
+Python 3.9 is recommended:
 
 ```bash
 git clone https://github.com/Zephor5/zspider.git
 cd zspider
+cp .env.example .env
+python3.9 -m venv .venv
+./.venv/bin/pip install -U pip setuptools wheel
+./.venv/bin/pip install -r requirements_dev.txt
 ```
 
-### 2. Install dependencies
+### 2) Start dependency services
 
 ```bash
-pip install -r requirements.txt
+make services-up
 ```
 
-### 3. Start external services
+This starts:
+
+- MongoDB
+- RabbitMQ
+- Memcached
+
+### 3) Start the local ZSpider stack
 
 ```bash
-docker compose -f docker-compose.services.yml up -d
+make dev
 ```
 
-### 4. Start ZSpider components
+This unified entry point starts:
+
+- `zspider.dispatcher`
+- `zspider.crawler`
+- `zspider.web`
+
+Default URL:
+
+```text
+http://127.0.0.1:5000
+```
+
+### 4) Initialize the admin account
+
+On the first visit to `/login`:
+
+- enter **any username and password**
+- if the user table is empty, that credential pair becomes the **initial admin account**
+
+So there is no hard-coded default admin account today. The **first successful login creates the initial admin user**.
+
+### 5) Verify the setup
+
+- open the dashboard and confirm it loads
+- log in and verify task pages open normally
+- inspect `logs/web.log`, `logs/dispatcher.log`, and `logs/crawler.log` for errors
+
+Stop everything with:
 
 ```bash
-python -m zspider.dispatcher
-python -m zspider.crawler
-python -m zspider.web
+# Ctrl + C stops the local processes started by make dev
+make services-down
 ```
-
-> For environment requirements, configuration details, components, parser model, pipelines, and project structure, see `docs/` or Read the Docs.
 
 ---
 
-## System Architecture
+## Unified local development flow
 
+To reduce first-run friction, the repository now provides one local entry point:
+
+```bash
+make dev
 ```
+
+It will:
+
+1. bring up dependency services from `docker-compose.services.yml`
+2. start dispatcher / crawler / web from the repo `.venv`
+3. write logs to `logs/dispatcher.log`, `logs/crawler.log`, and `logs/web.log`
+
+If you only want the dependency services:
+
+```bash
+make services-up
+```
+
+If you only want tests:
+
+```bash
+make test
+```
+
+---
+
+## Basic trust signals
+
+For phase one, the goal is to improve the fastest trust-building signals:
+
+- **GitHub Actions CI** added for unit tests
+- the repository currently includes **27 unit tests**, runnable via `make test`
+- `docs/` remains available as the deeper developer documentation entry
+- README now covers positioning, use cases, quick start, admin initialization, and the unified startup path
+
+Still worth adding later:
+
+- dashboard screenshots / GIFs
+- more realistic task templates
+- clearer production deployment docs
+- better health / observability docs
+
+---
+
+## System architecture
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                        ZSpider System                       │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
-│   ┌──────────────┐      ┌──────────────┐                    │
-│   │  Dispatcher  │◄────►│  Dispatcher  │  (Hot standby)     │
-│   │   (Master)   │      │   (Backup)   │                    │
-│   └──────┬───────┘      └──────────────┘                    │
-│          │                                                  │
-│          ▼                                                  │
-│   ┌──────────────┐                                          │
-│   │   RabbitMQ   │  Task Queue                              │
-│   └──────┬───────┘                                          │
-│          │                                                  │
-│          ▼                                                  │
-│   ┌──────────────┐   ┌──────────────┐   ┌──────────────┐    │
-│   │   Crawler    │   │   Crawler    │   │   Crawler    │    │
-│   │   (Worker)   │   │   (Worker)   │   │   (Worker)   │    │
-│   └──────┬───────┘   └──────────────┘   └──────────────┘    │
-│          │                                                  │
-│          ▼                                                  │
-│   ┌──────────────┐                                          │
-│   │   MongoDB    │  Data Storage                            │
-│   └──────────────┘                                          │
+│   Dispatcher  →  RabbitMQ  →  Crawler Workers              │
+│        │                               │                    │
+│        └──────── status / control ─────┘                    │
 │                                                             │
-│   ┌──────────────┐                                          │
-│   │  Memcached   │  Heartbeat + Deduplication               │
-│   └──────────────┘                                          │
-│                                                             │
-│   ┌──────────────┐                                          │
-│   │  Web Admin   │  Management Dashboard                    │
-│   └──────────────┘                                          │
+│   MongoDB   stores tasks and crawl results                  │
+│   Memcached heartbeat and deduplication                     │
+│   Web Admin backend management and review                   │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## Further Reading for Developers
+## Further reading
 
-- [Developer Guide](docs/developer_guide.rst): requirements, configuration, core components, parsers, pipelines, project structure
-- [Desgin](docs/desgin.rst): architecture design notes
-- [Internal Message](docs/internal_message.rst): internal messaging details
-- [Item Info](docs/item_info.rst): item and field model reference
+- [Developer Guide](docs/developer_guide.rst)
+- [Desgin](docs/desgin.rst)
+- [Internal Message](docs/internal_message.rst)
+- [Item Info](docs/item_info.rst)
 
-Build docs with Sphinx:
+Build docs with:
 
 ```bash
 cd docs
 make html
 ```
 
-Or visit [ReadTheDocs](http://zspider.readthedocs.org/)
+Or visit [Read the Docs](http://zspider.readthedocs.org/).
 
 ---
 
@@ -161,8 +207,6 @@ Or visit [ReadTheDocs](http://zspider.readthedocs.org/)
 
 MIT License
 
----
-
 ## Contributing
 
-Issues and Pull Requests are welcome!
+Issues and Pull Requests are welcome.

--- a/constraints/py39.txt
+++ b/constraints/py39.txt
@@ -1,0 +1,107 @@
+# Tested Python 3.9 dependency lock for local development and CI.
+#
+# Keep requirements*.txt focused on direct dependencies and use this constraints
+# file to force a known-good transitive resolution. This prevents environment
+# drift between a developer machine and GitHub Actions.
+#
+# Refresh flow:
+#   python3.9 -m venv /tmp/zspider-lock
+#   /tmp/zspider-lock/bin/pip install -U pip setuptools wheel
+#   /tmp/zspider-lock/bin/pip install -r requirements_dev.txt -c constraints/py39.txt
+#   /tmp/zspider-lock/bin/pip freeze
+
+alabaster==0.7.16
+APScheduler==3.10.4
+attrs==25.4.0
+Automat==25.4.16
+babel==2.18.0
+blinker==1.9.0
+certifi==2026.2.25
+cffi==2.0.0
+cfgv==3.4.0
+charset-normalizer==3.4.5
+click==8.1.8
+constantly==23.10.4
+cryptography==41.0.7
+cssselect==1.3.0
+distlib==0.4.0
+dnspython==2.7.0
+docutils==0.19
+email-validator==2.3.0
+exceptiongroup==1.3.1
+filelock==3.19.1
+Flask==2.2.5
+flask-mongoengine==1.0.0
+Flask-WTF==1.2.2
+graphviz==0.21
+h11==0.16.0
+hyperlink==21.0.0
+identify==2.6.15
+idna==3.11
+imagesize==1.5.0
+importlib_metadata==8.7.1
+Incremental==24.11.0
+itemadapter==0.13.1
+itemloaders==1.3.2
+itsdangerous==2.2.0
+Jinja2==3.1.6
+jmespath==1.1.0
+lxml==6.0.2
+MarkupSafe==3.0.3
+mock==5.0.1
+mongoengine==0.27.0
+netifaces==0.11.0
+nodeenv==1.10.0
+objgraph==3.5.0
+outcome==1.3.0.post0
+packaging==26.0
+parsel==1.10.0
+pika==1.3.2
+platformdirs==4.4.0
+pooled-pika==0.3.0
+pre-commit==3.2.2
+Protego==0.5.0
+pyasn1==0.6.2
+pyasn1_modules==0.4.2
+pycparser==2.23
+PyDispatcher==2.0.7
+Pygments==2.19.2
+pymongo==4.3.3
+pyOpenSSL==23.3.0
+PySocks==1.7.1
+python-discovery==1.1.3
+python-memcached==1.59
+pytz==2026.1.post1
+PyYAML==6.0.3
+queuelib==1.8.0
+requests==2.32.5
+requests-file==3.0.1
+Scrapy==2.8.0
+selenium==4.8.3
+service-identity==24.2.0
+six==1.17.0
+sniffio==1.3.1
+snowballstemmer==3.0.1
+sortedcontainers==2.4.0
+Sphinx==6.1.3
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==2.0.0
+sphinxcontrib-serializinghtml==2.0.0
+tldextract==5.3.0
+tomli==2.4.0
+trio==0.31.0
+trio-websocket==0.12.2
+Twisted==22.10.0
+typing_extensions==4.15.0
+tzlocal==5.3.1
+urllib3==1.26.20
+virtualenv==21.2.0
+w3lib==2.3.1
+Werkzeug==2.2.3
+wsproto==1.2.0
+WTForms==3.2.1
+zipp==3.23.0
+zope.interface==8.0.1

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -7,7 +7,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: mongoadmin
       MONGO_INITDB_ROOT_PASSWORD: mongopwd
     ports:
-      - "27017:27017"
+      - "${MONGO_PORT:-27017}:27017"
     volumes:
       - mongodb_data:/data/db
 
@@ -16,8 +16,8 @@ services:
     container_name: zspider-rabbitmq
     restart: unless-stopped
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "${RABBITMQ_PORT:-5672}:5672"
+      - "${RABBITMQ_MANAGEMENT_PORT:-15672}:15672"
     volumes:
       - ./docker/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
       - rabbitmq_data:/var/lib/rabbitmq
@@ -28,7 +28,7 @@ services:
     restart: unless-stopped
     command: ["memcached", "-m", "128", "-p", "11211", "-u", "memcache", "-vv"]
     ports:
-      - "11211:11211"
+      - "${MEMCACHED_PORT:-11211}:11211"
 
 volumes:
   mongodb_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./logs/mongodb:/var/log/mongodb:delegated
     shm_size: "2gb"
     ports:
-      - "5000:5000"
+      - "${WEB_PORT:-5000}:5000"
     environment:
       - "DOCKER_USER=${USER:-app}"
     hostname: "$USER"

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -6,6 +6,25 @@ This guide is for developers who want to understand, extend, or operate ZSpider 
 Requirements
 ------------
 
+First-run shortcut
+------------------
+
+If you only want to get a local instance running quickly:
+
+.. code-block:: bash
+
+   cp .env.example .env
+   python3.9 -m venv .venv
+   ./.venv/bin/pip install -U pip setuptools wheel
+   ./.venv/bin/pip install -r requirements_dev.txt
+   make services-up
+   make dev
+
+Then open ``http://127.0.0.1:5000/login``.
+
+When the user table is empty, the first username + password you submit becomes the initial admin account.
+
+
 Python Version
 ~~~~~~~~~~~~~~
 

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -16,7 +16,7 @@ If you only want to get a local instance running quickly:
    cp .env.example .env
    python3.9 -m venv .venv
    ./.venv/bin/pip install -U pip setuptools wheel
-   ./.venv/bin/pip install -r requirements_dev.txt
+   ./.venv/bin/pip install -r requirements_dev.txt -c constraints/py39.txt
    make services-up
    make dev
 
@@ -46,7 +46,7 @@ Recommended Development Environment
    python -m venv .venv
    . .venv/bin/activate
    pip install -U pip setuptools wheel
-   pip install -r requirements_dev.txt
+   pip install -r requirements_dev.txt -c constraints/py39.txt
 
 External Dependencies
 ~~~~~~~~~~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ pooled-pika~=0.3.0
 python-memcached==1.59
 
 # crawl_daemon
-pyopenssl==22.0.0
+# Scrapy/Twisted pull TLS dependencies transitively; the tested versions are
+# locked in constraints/py39.txt so local development and CI resolve the same
+# stack.
 scrapy~=2.8.0
 selenium==4.8.3

--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="${PYTHON_BIN:-$ROOT_DIR/.venv/bin/python}"
+LOG_DIR="${LOG_DIR:-$ROOT_DIR/logs}"
+WEB_PORT="${WEB_PORT:-5000}"
+WEB_HOST="${WEB_HOST:-127.0.0.1}"
+START_SERVICES="${START_SERVICES:-1}"
+
+mkdir -p "$LOG_DIR"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "Python runtime not found: $PYTHON_BIN"
+  echo "Create the venv first, for example: python3.9 -m venv .venv && .venv/bin/pip install -r requirements_dev.txt"
+  exit 1
+fi
+
+if [[ "$START_SERVICES" == "1" ]]; then
+  docker compose -f docker-compose.services.yml up -d
+fi
+
+pids=()
+
+cleanup() {
+  if [[ ${#pids[@]} -gt 0 ]]; then
+    echo "Stopping ZSpider processes..."
+    kill "${pids[@]}" 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+start_component() {
+  local name="$1"
+  shift
+  echo "Starting $name ..."
+  if [[ "$name" == "web" ]]; then
+    ZSPIDER_WEB_HOST="$WEB_HOST" "$PYTHON_BIN" -m "$@" > "$LOG_DIR/${name}.log" 2>&1 &
+  else
+    "$PYTHON_BIN" -m "$@" > "$LOG_DIR/${name}.log" 2>&1 &
+  fi
+  pids+=("$!")
+}
+
+start_component dispatcher zspider.dispatcher
+start_component crawler zspider.crawler
+start_component web zspider.web "$WEB_PORT"
+
+echo
+cat <<MSG
+ZSpider is starting.
+
+Web admin: http://127.0.0.1:${WEB_PORT}
+First login: any username + password creates the initial admin account when the user table is empty.
+Logs:
+  - $LOG_DIR/dispatcher.log
+  - $LOG_DIR/crawler.log
+  - $LOG_DIR/web.log
+
+Press Ctrl+C to stop all local processes started by this script.
+MSG
+
+echo
+wait -n "${pids[@]}"

--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -14,7 +14,7 @@ mkdir -p "$LOG_DIR"
 
 if [[ ! -x "$PYTHON_BIN" ]]; then
   echo "Python runtime not found: $PYTHON_BIN"
-  echo "Create the venv first, for example: python3.9 -m venv .venv && .venv/bin/pip install -r requirements_dev.txt"
+  echo "Create the venv first, for example: python3.9 -m venv .venv && .venv/bin/pip install -r requirements_dev.txt -c constraints/py39.txt"
   exit 1
 fi
 

--- a/zspider/web.py
+++ b/zspider/web.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import os
 import sys
 import threading
 
@@ -19,11 +20,12 @@ def main():
     t = threading.Thread(target=test_crawler.start, args=(False, False))
     t.setDaemon(True)
     t.start()
+    host = os.getenv("ZSPIDER_WEB_HOST", INNER_IP)
     if len(sys.argv) == 2:
         port = int(sys.argv[1])
-        app.run(host=INNER_IP, port=port)
+        app.run(host=host, port=port)
     else:
-        app.run(host=INNER_IP, debug=True)
+        app.run(host=host, debug=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reposition the README around content monitoring / news aggregation use cases
- add a 5-minute quickstart, unified local startup flow, and first-admin initialization guidance
- add `.env.example`, a Makefile, a local dev startup script, and a basic CI workflow
- make web binding/compose ports easier to override for local first-run experience

## Validation
- `make test`
- `make dev`
- `curl -I http://127.0.0.1:5000/login`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Zephor5/zspider/16)
<!-- Reviewable:end -->
